### PR TITLE
Fix code editor width

### DIFF
--- a/manager/components/console/js/widgets/console.panel.js
+++ b/manager/components/console/js/widgets/console.panel.js
@@ -95,7 +95,7 @@ ModConsole.panel.CodeEditor = function(config) {
 			,xtype: Ext.ComponentMgr.types['modx-texteditor'] ? 'modx-texteditor' : 'textarea'
 			,mimeType: 'application/x-php'
 			,height: 300
-			,width: 'auto'
+			,width: '97%'
 			,style: {
 				margin: '15px'
 			}


### PR DESCRIPTION
Displays code editor text box at full width (less padding). Helpful for running code even when no rich text editor is installed or configured for elements.